### PR TITLE
[Fix] Skip parent_foreign_key integer casting

### DIFF
--- a/app/controllers/fae/nested_base_controller.rb
+++ b/app/controllers/fae/nested_base_controller.rb
@@ -11,8 +11,7 @@ module Fae
       @item = @klass.new
       raise_undefined_parent if @item.fae_nested_foreign_key.blank?
 
-      item_id = params[:item_id].to_i || nil
-      @item.send("#{parent_foreign_key}=", item_id)
+      @item.send("#{parent_foreign_key}=", params[:item_id])
       build_assets
     end
 


### PR DESCRIPTION
- which breaks, when foreign key is UUID
- and also is redundant, since AR can handle integers represented as
string